### PR TITLE
Fix the enum validator typing

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -22,7 +22,7 @@ export interface IKoiSchema extends Joi.AnySchema {
     time(): this;
     date(): this;
     endDate(): this;
-    enum(jsEnum: object): this;
+    enum<E extends { [P in keyof E]: string }>(jsEnum: E): this;
 }
 
 export const Koi: IKoi = Joi.extend([
@@ -72,8 +72,9 @@ export const Koi: IKoi = Joi.extend([
             },
             {
                 name: 'enum',
-                params: { jsEnum: Joi.object().pattern(/.*/, Joi.string()) },
-                validate(params: { jsEnum: object }, value: any, state: Joi.State, options: Joi.ValidationOptions) {
+                params: { jsEnum: Joi.object().pattern(/.*/, Joi.string().required()) },
+                validate(params: { jsEnum: { [key: string]: string } }, value: any, state: Joi.State,
+                         options: Joi.ValidationOptions) {
                     if (values(params.jsEnum).includes(value)) {
                         return value;
                     } else {


### PR DESCRIPTION
Passing an argument of type object into lodash.values results in a
never[] being returned, due to the object type not having keys. With
this fix, only objects/enums with string values can be passed in.

The type of the interface and the validate function differ, because
the Joi.validate function doesn't allow us to add a generic type.